### PR TITLE
Added custom plant icons and tested with gatsby build / serve

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -13,7 +13,7 @@ const Card = ({ water, src, name }) => {
       </div>
       {/* image tag with styles and src */}
       <img
-        style={{ width: "125px", height: "125px" }}
+        style={{ width: "225px", height: "225px", paddingBottom:"40px" }}
         className="mx-auto"
         src={src}
         alt={name}

--- a/src/data/data.json
+++ b/src/data/data.json
@@ -3,66 +3,66 @@
     "name": "Fiddle Leaf Fig",
     "water_after": "7 days",
     "id": 0,
-    "src": "../../cactus.svg"
+    "src": "../../plant0.jpg"
   },
   {
     "name": "Snake Plant",
     "water_after": "14 days",
     "id": 1,
-    "src": "../../camellia.svg"
+    "src": "../../plant1.jpg"
   },
   {
     "name": "Money Tree",
     "water_after": "14 days",
     "id": 2,
-    "src": "../../crops.svg"
+    "src": "../../plant2.jpg"
   },
   {
     "name": "Bird's Nest Fern",
     "water_after": "3 days",
     "id": 3,
-    "src": "../../flower.svg"
+    "src": "../../plant3.jpg"
   },
   {
     "name": "Croton",
     "water_after": "7 days",
     "id": 4,
-    "src": "../../green-tea.svg"
+    "src": "../../plant4.jpg"
   },
   {
     "name": "Bell Pepper Plant",
     "water_after": "3 days",
     "id": 5,
-    "src": "../../idea.svg"
+    "src": "../../plant5.jpg"
   },
   {
     "name": "Strawberry Plant",
     "water_after": "3 days",
     "id": 6,
-    "src": "../../plant.svg"
+    "src": "../../plant6.jpg"
   },
   {
     "name": "Dracaena",
     "water_after": "14 days",
     "id": 7,
-    "src": "../../plant1.svg"
+    "src": "../../plant7.jpg"
   },
   {
     "name": "Spider Plant",
     "water_after": "7 days",
     "id": 8,
-    "src": "../../plant2.svg"
+    "src": "../../plant8.jpg"
   },
   {
     "name": "Jade",
     "water_after": "14 days",
     "id": 9,
-    "src": "../../rose.svg"
+    "src": "../../plant9.jpg"
   },
   {
     "name": "Wavy Fern",
     "water_after": "2 days",
     "id": 10,
-    "src": "../../tulips.svg"
+    "src": "../../plant10.jpg"
   }
 ]


### PR DESCRIPTION
Added all the custom plant icons and did a Gatsby build and Gatsby serve to run on localhost:9000 and the site was working fine. I also made the icons a bit bigger and added more bottom padding beneath them to lift them off the bottom of the card a bit.